### PR TITLE
Properly handle overflows while tempering

### DIFF
--- a/tinymt.py
+++ b/tinymt.py
@@ -40,8 +40,8 @@ class TinyMT(object):
     def nextStateAsPID(self):
         # Return next state as a PID (32 bit integer)
         self.nextState()
-        tmp = self.state[0] + (self.state[2] >> 8)
-        return (tmp ^ self.state[3] ^ -(tmp & 0x1) & self.tmat) & 0xFFFFFFFF
+        tmp = (self.state[0] + (self.state[2] >> 8)) & 0xFFFFFFFF
+        return (tmp ^ self.state[3] ^ -(tmp & 0x1) & self.tmat)
 
     def nextStateAsInt(self, limit):
         # Return next state as an integer 0-limit

--- a/tinymt.py
+++ b/tinymt.py
@@ -41,7 +41,7 @@ class TinyMT(object):
         # Return next state as a PID (32 bit integer)
         self.nextState()
         tmp = self.state[0] + (self.state[2] >> 8)
-        return (tmp ^ self.state[3] ^ -(tmp & 0x1) & self.tmat)
+        return (tmp ^ self.state[3] ^ -(tmp & 0x1) & self.tmat) & 0xFFFFFFFF
 
     def nextStateAsInt(self, limit):
         # Return next state as an integer 0-limit


### PR DESCRIPTION
This appears to be the cause of the various incorrect results. When `self.state[0] + (self.state[2] >> 8)` is larger than 2^32, the python code here includes that 2^32 bit in the output while the corresponding C code implicitly removes it. Because the moduli used are often not powers of 2, this can cause incorrect natures, incorrect inheritance, etc. If it occurred during the rejection sampling for inherited IVs, it could cause fewer or extra rerolls, leading to incorrect directions to acquire the desired egg.

Here's a case for reproducing the bug:
seed: 17a56a9e f58f35a0 8880cfc0 2963762f
male is ditto, 1-1 gender ratio, no items
The resulting egg should be
Relaxed, Male, HP from male, 3 Atk, 5 Def, SpA from female, 30 SpD, Spe from female